### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/solutions-full-exercises/exercise 5/pom.xml
+++ b/solutions-full-exercises/exercise 5/pom.xml
@@ -74,7 +74,7 @@
           <id>camunda-bpm-nexus-ee</id>
           <name>camunda-bpm-nexus</name>
           <url>
-            https://app.camunda.com/nexus/content/repositories/camunda-bpm-ee
+            https://artifacts.camunda.com/artifactory/camunda-bpm-ee/
           </url>
         </repository>
       </repositories>

--- a/solutions-full-exercises/exercise 6/pom.xml
+++ b/solutions-full-exercises/exercise 6/pom.xml
@@ -74,7 +74,7 @@
           <id>camunda-bpm-nexus-ee</id>
           <name>camunda-bpm-nexus</name>
           <url>
-            https://app.camunda.com/nexus/content/repositories/camunda-bpm-ee
+            https://artifacts.camunda.com/artifactory/camunda-bpm-ee/
           </url>
         </repository>
       </repositories>


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



